### PR TITLE
Set firebase CLI to non-interactive mode on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ script:
 install:
  - npm install -g firebase-tools
 after_success:
- - firebase deploy --project listmiweb --token $FIREBASE_TOKEN
+ - firebase deploy --project listmiweb --token $FIREBASE_TOKEN --non-interactive


### PR DESCRIPTION
The firebase CLI fails on Travis without this flag.
Unfortunately the build appears OK, but the new website is not deployed.
In the Travis build log the error appears as below. 
```
FIREBASE WARNING: Exception was thrown by user callback. TypeError: this.stream.clearLine is not a function
    at ProgressBar.terminate (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/progress/lib/node-progress.js:177:17)
    at ProgressBar.tick (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/progress/lib/node-progress.js:91:10)
    at /home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/lib/deploy/hosting/deploy.js:65:17
    at /home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/firebase/lib/firebase-node.js:201:710
    at ec (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/firebase/lib/firebase-node.js:52:165)
    at ac (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/firebase/lib/firebase-node.js:31:216)
    at bc (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/firebase/lib/firebase-node.js:30:1259)
    at Ji.h.Ib (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/firebase/lib/firebase-node.js:220:287)
    at Rh.h.Jd (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/firebase/lib/firebase-node.js:186:283)
    at Fh.Jd (/home/travis/.nvm/versions/node/v6.11.0/lib/node_modules/firebase-tools/node_modules/firebase/lib/firebase-node.js:176:364) 
Error: An unexpected error has occurred.
```